### PR TITLE
Fixes crash on hopper item insertion into side of Induction Smelter

### DIFF
--- a/src/main/java/ua/pp/shurgent/tfctech/tileentities/TEInductionSmelter.java
+++ b/src/main/java/ua/pp/shurgent/tfctech/tileentities/TEInductionSmelter.java
@@ -606,9 +606,9 @@ public class TEInductionSmelter extends TileEnergyConsumer implements IInventory
 	 */
 	public int[] getAccessibleSlotsFromSide(int side) {
 		if (!ModOptions.cfgAllowAutomationInductionSmelter)
-			return null;
+			return new int[0];
 		
-		return side == 0 ? slotsBottom : (side == 1 ? slotsTop : null); // Resources and molds from top, result from bottom
+		return side == 0 ? slotsBottom : (side == 1 ? slotsTop : new int[0]); // Resources and molds from top, result from bottom
 	}
 	
 	/**


### PR DESCRIPTION
NullPointerException occured due to getAccesibleSlotsFromSide returning a null instead of an empty list of slots.

Additionally, this allows to put items not only from the top, but from the sides too, to give player more interaction-freedom (Which might have to be seperated into a different commit, if only two insertion points were very much intended)